### PR TITLE
support simple doc code block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.1.9
+
+### Support
+
+* Support abbreviated doc code blocks, such as `@doc "foo"`
+
 ## v0.1.8
 
 ### Document

--- a/example/example.api
+++ b/example/example.api
@@ -1,0 +1,45 @@
+/**
+ * api语法示例及语法说明
+ */
+
+// api语法版本
+syntax = "v1"
+
+// import literal
+import "foo.api"
+
+// import group
+import (
+    "bar.api"
+    "foo/bar.api"
+)
+info(
+    author: "username"
+    date:   "2020-01-08"
+    desc:   "api syntax example and syntax description"
+)
+
+// type literal
+
+type Foo{
+    Foo int `json:"foo"`
+}
+
+// type group
+
+type(
+    Bar{
+        Bar int `json:"bar"`
+    }
+)
+
+// service block
+@server(
+    jwt:   Auth
+    group: foo
+)
+service foo-api{
+    @doc "foo"
+    @handler foo
+    post /foo (Foo) returns (Bar)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "goctl",
-    "version": "0.1.7",
+    "version": "0.1.9",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "goctl",
-            "version": "0.1.7",
+            "version": "0.1.9",
             "dependencies": {
                 "tree-kill": "^1.2.2"
             },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "goctl",
     "displayName": "goctl",
     "description": "goctl visual studio code extension",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "publisher": "xiaoxin-technology",
     "icon": "images/go-zero-logo.png",
     "engines": {

--- a/syntaxes/goctl.tmLanguage.json
+++ b/syntaxes/goctl.tmLanguage.json
@@ -499,6 +499,9 @@
 					"include": "#doc"
 				},
 				{
+					"include": "#docSimple"
+				},
+				{
 					"include": "#server"
 				},
 				{
@@ -559,8 +562,13 @@
 		},
 		"doc": {
 			"name": "comment.doc.service.goctl",
-			"begin": "@doc",
+			"begin": "@doc\\s*\\(",
 			"end": "\\)"
+		},
+		"docSimple": {
+			"name": "comment.doc.service.goctl",
+			"begin": "@doc\\s*\"",
+			"end": "\""
 		},
 		"server": {
 			"name": "method.server.service.goctl",


### PR DESCRIPTION
Support simple doc code block. Released this feature in v0.1.9.

close #9 